### PR TITLE
Document `python:` prefix when loading assertions in CSV

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -229,6 +229,7 @@ All assertion types can be used in `__expected`. The column supports exactly one
 
 - `is-json` and `contains-json` are supported directly, and do not require any value
 - `fn` indicates `javascript` type. For example: `fn:output.includes('foo')`
+- `python` indicates `python` type. For example: `python:file://custom_assertion.py`
 - `similar` takes a threshold value. For example: `similar(0.8):hello world`
 - `grade` indicates `llm-rubric`. For example: `grade: does not mention being an AI`
 - By default, `__expected` will use type `equals`


### PR DESCRIPTION
When loading test assertions from CSV, [you can specify Python functions or files](https://github.com/promptfoo/promptfoo/blob/9fce9a875065653138882694ca043a5ebed94102/src/csv.ts#L70):


Mention that in the documentation!